### PR TITLE
Modified PayIn One Time Expiry API path

### DIFF
--- a/app/controller/payInController.js
+++ b/app/controller/payInController.js
@@ -1241,7 +1241,7 @@ class PayInController {
     }
   }
 
-  async expirePayInUrl(req, res, next) {
+  async expireOneTimeUrl(req, res, next) {
     try {
       checkValidation(req)
       const { id } = req.params;

--- a/app/routes/payinRouter.js
+++ b/app/routes/payinRouter.js
@@ -96,9 +96,9 @@ payInRouter.get(
 );
 
 payInRouter.post(
-  "/expire-url/:id",
+  "/expire-one-time-payin-url/:id",
   payInExpireURLValidator,
-  payInController.expirePayInUrl
+  payInController.expireOneTimeUrl
 );
 
 // telegram resp ocr

--- a/app/services/payInServices.js
+++ b/app/services/payInServices.js
@@ -7,7 +7,7 @@ import { nanoid } from "nanoid";
 class PayInService {
   async generatePayInUrl(getMerchantRes, payInData) {
     const _10_MINUTES = 1000 * 60 * 10;
-    const expirationDate = new Date().getTime() + _10_MINUTES;
+    const expirationDate = Math.floor((new Date().getTime() + _10_MINUTES) / 1000);
 
     const data = {
       upi_short_code: nanoid(5), // code added by us
@@ -20,12 +20,12 @@ class PayInService {
       return_url: getMerchantRes?.return_url,
       notify_url: getMerchantRes?.notify_url,
       merchant_id: getMerchantRes?.id,
-      expirationDate: Math.floor(expirationDate / 1000),
+      expirationDate,
     };
     const payInUrlRes = await payInRepo.generatePayInUrl(data);
     const updatePayInUrlRes = {
       ...payInUrlRes,
-      expirationDate: Math.floor(expirationDate / 1000),
+      expirationDate,
     };
     return updatePayInUrlRes;
   }


### PR DESCRIPTION
- Modified the API path of PayIn One Time Expire for better naming convention.
- Modified the controller function name of PayIn One Time Expiry for better naming convention.
- Removed Timestamp dividing with 1000 from two place and added it to top variable to make that calculation at once.