### PR TITLE
Changed the key of admin merchant children to childrenData

### DIFF
--- a/app/repository/merchantRepo.js
+++ b/app/repository/merchantRepo.js
@@ -209,7 +209,7 @@ class MerchantRepo {
     const transformedData = dataRes.reduce((acc, item) => {
       // Find children based on child_code and add them to the item
       if (item.child_code && item.child_code.length) {
-        item.children = item.child_code.map(code => {
+        item.childrenData = item.child_code.map(code => {
           return dataRes.find(child => child.code === code);
         }).filter(child => child);
       }


### PR DESCRIPTION
## Bug Explaination:

Antd Table was triggering Tree Data Structure flow with key `children`. Also we have implemented the expanded row renderer function therefore the rows was rendering in duplication.

## Solution:

Simply to solve this duplication i've chaned the key `children` to `childrenData`.